### PR TITLE
Have `safe-divide` return a double.

### DIFF
--- a/src/witan/datasets.clj
+++ b/src/witan/datasets.clj
@@ -9,8 +9,8 @@
 (defn safe-divide
   [[d dd]]
   (if (zero? dd)
-    0
-    (/ d dd)))
+    0.0
+    (/ ^double d dd)))
 
 (defn juxt-r
   [& fns]

--- a/test/witan/datasets_test.clj
+++ b/test/witan/datasets_test.clj
@@ -6,36 +6,40 @@
             [incanter.stats :as st]
             [incanter.datasets :as data]))
 
+(deftest safe-divide-test
+  (is (= 0.0 (wds/safe-divide [2 0])))
+  (is (= 0.4 (wds/safe-divide [2 5]))))
+
 (def data
   (ds/dataset [:label :label2 :value]
               (mapv conj
                     (cycle (for [f [:a :b :c]
                                  s [:x :y :z]]
                              [f s]))
-                    (range 100001))))
+                    (range 0.0 100001.0))))
 
 (def results
-  {:max {[] (ds/dataset [:value] [[100000]])
+  {:max {[] (ds/dataset [:value] [[100000.0]])
          [:label] (ds/dataset [:label :value]
-                              [[:a 100000] [:b 99995] [:c 99998]])
+                              [[:a 100000.0] [:b 99995.0] [:c 99998.0]])
          [:label :label2] (ds/dataset [:label :label2 :value]
-                                      [[:a :x 99999] [:a :y 100000] [:a :z 99992]
-                                       [:b :x 99993] [:b :y 99994] [:b :z 99995]
-                                       [:c :x 99996] [:c :y 99997] [:c :z 99998]])}
-   :min {[] (ds/dataset [:value] [[0]])
+                                      [[:a :x 99999.0] [:a :y 100000.0] [:a :z 99992.0]
+                                       [:b :x 99993.0] [:b :y 99994.0] [:b :z 99995.0]
+                                       [:c :x 99996.0] [:c :y 99997.0] [:c :z 99998.0]])}
+   :min {[] (ds/dataset [:value] [[0.0]])
          [:label] (ds/dataset [:label :value]
-                              [[:a 0] [:b 3] [:c 6]])
+                              [[:a 0.0] [:b 3.0] [:c 6.0]])
          [:label :label2] (ds/dataset [:label :label2 :value]
-                                      [[:a :x 0] [:a :y 1] [:a :z 2]
-                                       [:b :x 3] [:b :y 4] [:b :z 5]
-                                       [:c :x 6] [:c :y 7] [:c :z 8]])}
-   :sum {[] (ds/dataset [:value] [[5000050000]])
+                                      [[:a :x 0.0] [:a :y 1.0] [:a :z 2.0]
+                                       [:b :x 3.0] [:b :y 4.0] [:b :z 5.0]
+                                       [:c :x 6.0] [:c :y 7.0] [:c :z 8.0]])}
+   :sum {[] (ds/dataset [:value] [[5000050000.0]])
          [:label] (ds/dataset [:label :value]
-                              [[:a 1666716667] [:b 1666616667] [:c 1666716666]])
+                              [[:a 1666716667.0] [:b 1666616667.0] [:c 1666716666.0]])
          [:label :label2] (ds/dataset [:label :label2 :value]
-                                      [[:a :x 555594444] [:a :y 555605556] [:a :z 555516667]
-                                       [:b :x 555527778] [:b :y 555538889] [:b :z 555550000]
-                                       [:c :x 555561111] [:c :y 555572222] [:c :z 555583333]])}
+                                      [[:a :x 555594444.0] [:a :y 555605556.0] [:a :z 555516667.0]
+                                       [:b :x 555527778.0] [:b :y 555538889.0] [:b :z 555550000.0]
+                                       [:c :x 555561111.0] [:c :y 555572222.0] [:c :z 555583333.0]])}
    :count {[] (ds/dataset [:value] [[100001]])
            [:label] (ds/dataset [:label :value]
                                 [[:a 33335] [:b 33333] [:c 33333]])
@@ -43,21 +47,26 @@
                                         [[:a :x 11112] [:a :y 11112] [:a :z 11111]
                                          [:b :x 11111] [:b :y 11111] [:b :z 11111]
                                          [:c :x 11111] [:c :y 11111] [:c :z 11111]])}
-   :mean {[] (ds/dataset [:value] [[50000]])
+   :mean {[] (ds/dataset [:value] [[50000.0]])
           [:label] (ds/dataset [:label :value]
-                               [[:a (/ 1666716667 33335)] [:b 49999] [:c 50002]])
+                               [[:a (/ 1666716667.0 33335.0)] [:b 49999.0] [:c 50002.0]])
           [:label :label2] (ds/dataset [:label :label2 :value]
-                                       [[:a :x (/ 555594444 11112)] [:a :y (/ 555605556 11112)] [:a :z (/ 555516667 11111)]
-                                        [:b :x (/ 555527778 11111)] [:b :y (/ 555538889 11111)] [:b :z (/ 555550000 11111)]
-                                        [:c :x (/ 555561111 11111)] [:c :y (/ 555572222 11111)] [:c :z (/ 555583333 11111)]])}})
+                                       [[:a :x (/ 555594444.0 11112.0)]
+                                        [:a :y (/ 555605556.0 11112.0)]
+                                        [:a :z (/ 555516667.0 11111.0)]
+                                        [:b :x (/ 555527778.0 11111.0)]
+                                        [:b :y (/ 555538889.0 11111.0)]
+                                        [:b :z (/ 555550000.0 11111.0)]
+                                        [:c :x (/ 555561111.0 11111.0)]
+                                        [:c :y (/ 555572222.0 11111.0)]
+                                        [:c :z (/ 555583333.0 11111.0)]])}})
 
 (deftest rollup
   (doseq [aggregate [:max :min :sum :count :mean]
           groupby [[] [:label] [:label :label2]]]
     (is
-     (=
-      (get-in results [aggregate groupby])
-      (wds/rollup data aggregate :value groupby))
+     (= (get-in results [aggregate groupby])
+        (wds/rollup data aggregate :value groupby))
      (str "Checking " aggregate " grouped by " groupby))))
 
 (def data-size 10000)


### PR DESCRIPTION
Add a test for `safe-divide` and modify the test data for `rollup`.
