### PR TITLE
Added 'required-key' to default keys

### DIFF
--- a/src/witan/workspace_api.clj
+++ b/src/witan/workspace_api.clj
@@ -20,20 +20,20 @@
 
 (def WorkflowFnMetaData
   "Schema for the Witan workflow function metadata"
-  {:witan/name          s/Keyword
-   :witan/version       s/Str
-   :witan/input-schema  {s/Keyword s/Any}
-   :witan/output-schema {s/Keyword s/Any}
-   :witan/doc           s/Str
+  {(s/required-key :witan/name)          s/Keyword
+   (s/required-key :witan/version)       s/Str
+   (s/required-key :witan/input-schema)  {s/Keyword s/Any}
+   (s/required-key :witan/output-schema) {s/Keyword s/Any}
+   (s/required-key :witan/doc)           s/Str
    (s/optional-key :witan/param-schema) {s/Any s/Any}
    (s/optional-key :witan/exported?) s/Bool})
 
 (def WorkflowPredicateMetaData
   "Schema for the Witan workflow predicate metadata"
-  {:witan/name          s/Keyword
-   :witan/version       s/Str
-   :witan/input-schema  {s/Keyword s/Any}
-   :witan/doc           s/Str
+  {(s/required-key :witan/name)          s/Keyword
+   (s/required-key :witan/version)       s/Str
+   (s/required-key :witan/input-schema)  {s/Keyword s/Any}
+   (s/required-key :witan/doc)           s/Str
    (s/optional-key :witan/param-schema) {s/Any s/Any}
    (s/optional-key :witan/exported?) s/Bool})
 


### PR DESCRIPTION
I think the issue with using `optional-keys` is that the 'other' keys need to be declared as required keys.

At the very least the changes I have made don't break anything. To really test whether this fixes the issue we need to call the api from our demography project
