### PR TITLE
Add `definput` macro

### DIFF
--- a/src/witan/workspace_api.clj
+++ b/src/witan/workspace_api.clj
@@ -174,6 +174,26 @@
                     :witan/metadata
                     ModelMetaData ~metadata))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; refactored input
+
+(defmacro definput
+  [fname {:keys [witan/version
+                 witan/schema
+                 witan/key
+                 witan/name] :as args}]
+  `(defworkflowinput ~fname
+     "made-with-make-input-macro"
+     {:witan/name ~name
+      :witan/version ~version
+      :witan/output-schema {~key ~schema}
+      :witan/param-schema {:src s/Str
+                           :fn  (s/pred fn?)}}
+     [inputs# params#]
+     (let [fn#  (:fn params#)
+           src# (:src params#)]
+       {~key (fn# src# ~schema)})))
+
 (defmacro merge->
   [data & forms]
   `(apply merge ~@(map list (repeat '->) (repeat data) forms)))


### PR DESCRIPTION
This is a wrapper around `defworkflowinput`. Bear with me. Whilst trying
to get the workspace execution going, it's become obvious that the
current input mechanism is a bit too open. It's intended that we'll
eventually replace `defworkflowinput` entirely with this new style.
