### PR TITLE
Fix defmodel schema validation

### DIFF
--- a/src/witan/workspace_api.clj
+++ b/src/witan/workspace_api.clj
@@ -164,12 +164,12 @@
   "Macro for defining a workflow model"
   [name & body] ;; metadata args &body
   (let [[doc metadata body] (carve-body body)
-        metadata (assoc metadata :witan/type :model)
-        _ (s/validate Model (first body))]
+        metadata (assoc metadata :witan/type :model)]
     `(do
        (def ~name
          ~doc
          ~@body)
+       (s/validate Model ~@body)
        (assign-meta #'~name
                     :witan/metadata
                     ModelMetaData ~metadata))))

--- a/src/witan/workspace_api.clj
+++ b/src/witan/workspace_api.clj
@@ -166,10 +166,10 @@
   (let [[doc metadata body] (carve-body body)
         metadata (assoc metadata :witan/type :model)]
     `(do
+       (s/validate Model ~@body)
        (def ~name
          ~doc
          ~@body)
-       (s/validate Model ~@body)
        (assign-meta #'~name
                     :witan/metadata
                     ModelMetaData ~metadata))))

--- a/test/witan/workspace_api_test.clj
+++ b/test/witan/workspace_api_test.clj
@@ -83,6 +83,41 @@
               :witan/fn :test.fn/inc
               :witan/version "1.0.0"}]})
 
+(def model-workflow
+  [[:in :a]
+   [:b  :c]
+   [:c  :out]])
+
+(def model-catalog
+  [{:witan/name :in
+    :witan/fn :test.fn/inc
+    :witan/type :input
+    :witan/version "1.0.0"
+    :witan/params {:foo "bar"}}
+   {:witan/name :a
+    :witan/type :function
+    :witan/fn :test.fn/inc
+    :witan/version "1.0.0"}
+   {:witan/name :b
+    :witan/type :function
+    :witan/fn :test.fn/inc
+    :witan/version "1.0.0"}
+   {:witan/name :c
+    :witan/type :function
+    :witan/fn :test.fn/inc
+    :witan/version "1.0.0"}
+   {:witan/name :out
+    :witan/type :output
+    :witan/fn :test.fn/inc
+    :witan/version "1.0.0"}])
+
+(defmodel default-model-2
+  "doc"
+  {:witan/name :default
+   :witan/version "1.0.0"}
+  {:workflow model-workflow
+   :catalog model-catalog})
+
 ;; predicate
 (defworkflowpred less-than
   "pred doc"
@@ -222,7 +257,33 @@
                        :witan/type :output
                        :witan/fn :test.fn/inc
                        :witan/version "1.0.0"}]}
-           default-model))))
+           default-model)))
+  (testing "model workflow and catalog can be def-ed outside defmodel"
+    (is (= {:workflow [[:in :a]
+                       [:b  :c]
+                       [:c  :out]]
+            :catalog [{:witan/name :in
+                       :witan/fn :test.fn/inc
+                       :witan/type :input
+                       :witan/version "1.0.0"
+                       :witan/params {:foo "bar"}}
+                      {:witan/name :a
+                       :witan/type :function
+                       :witan/fn :test.fn/inc
+                       :witan/version "1.0.0"}
+                      {:witan/name :b
+                       :witan/type :function
+                       :witan/fn :test.fn/inc
+                       :witan/version "1.0.0"}
+                      {:witan/name :c
+                       :witan/type :function
+                       :witan/fn :test.fn/inc
+                       :witan/version "1.0.0"}
+                      {:witan/name :out
+                       :witan/type :output
+                       :witan/fn :test.fn/inc
+                       :witan/version "1.0.0"}]}
+           default-model-2))))
 
 (deftest workflowpred-meta
   (testing "Is predicate metadata applied?"


### PR DESCRIPTION
- On @acron0's instructions I moved `defmodel` schema validation within the quoted expression of the macro.
- I added a test to check models can be defined when their workflow and catalog are def-ed separately.
